### PR TITLE
Update abuseipdb.sh

### DIFF
--- a/abuseipdb.sh
+++ b/abuseipdb.sh
@@ -113,10 +113,6 @@ ensure_rule_at_top() {
   else
     FIRST_RULE=$($cmd -S $chain | sed -n '2p')
     if [[ "$FIRST_RULE" != *"$rule"* ]]; then
-      
-      for line in $($cmd -nL MAILCOW --line-numbers | grep 'MAILCOW-DROP' | awk '{print $1}' | sort -rn); do
-        $cmd -D MAILCOW "$line"
-      done
       eval "$cmd -D $chain $rule"  # Remove old rule
       eval "$cmd -I $chain 1 $rule"  # Reinsert at the top
     fi


### PR DESCRIPTION
Removed the routine for deleting log rules in the ensure_rule_at_top() method, as this takes place in a later step.

Hallo. Vielen Dank für die Bereitstellung des Skripts. Ich möchte das die Tage auch auf meiner Mailcow Installation einsetzen. Beim Durchsehen des Skripts ist mir aber möglicherweise ein kleiner Fehler aufgefallen, bin mir aber nicht ganz sicher. Wenn ich das richtig sehe, löschst du in der ensure_rule_at_top() Methode die LOG Einträge (MAILCOW-DROP). Ich denke, das gehört da nicht hin, da es ja später je nach gesetzter Option --enable-log ja sowieso passiert(?). Bitte entschuldige, wenn ich jetzt was falsches gemacht habe. Das sind meine ersten Gehversuche auf Github... Gruß